### PR TITLE
Set minimum `node` version to 18.3 in `package.json` `engines` due to `utils.parseArgs` usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "npm"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=18.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #7 